### PR TITLE
make input stream reset optional (fixes #1)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,12 @@
-(defproject clojure-paypal-ipn "0.0.1-SNAPSHOT"
+(defproject clojure-paypal-ipn "0.0.2-SNAPSHOT"
   :description "PayPal IPN handler for Clojure. Use with ring, compojure, or any clojure server env."
   :url "https://github.com/smallhelm/clojure-paypal-ipn"
   :license {:name "The MIT License (MIT)"
             :url "http://opensource.org/licenses/MIT"}
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-http "0.9.2"]]
+                 [clj-http "1.1.1"]]
+
   :source-paths ["src"]
 
   :profiles {:dev {:plugins [[quickie "0.2.5"]]}})


### PR DESCRIPTION
Many Clojure ring servers don’t support input stream reset for post
requests, so make it optional.
Also, update http lib to latest version.
